### PR TITLE
add new optional file_path argument 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip3 install rofi_browser_bookmarks
 ## Usage
 
 ```bash
-rofi-browser-bookmarks BROWSER [folder]
+rofi-browser-bookmarks BROWSER [folder] [file_path]
 ```
 
 Currently only `google-chrome` is a supported browser.

--- a/rofi_browser_bookmarks/ChromeBookmarksParser.py
+++ b/rofi_browser_bookmarks/ChromeBookmarksParser.py
@@ -5,8 +5,12 @@ from subprocess import CalledProcessError
 import json
 
 class ChromeBookmarksParser:
-    def parse(self, folder=None) -> str:
-        bookmarks_path = path.expanduser("~") + "/.config/google-chrome/Default/Bookmarks"
+    def parse(self, folder=None, file_path=None) -> str:
+        if file_path is None:
+            bookmarks_path = path.expanduser("~") + "/.config/google-chrome/Default/Bookmarks"
+        else:
+            bookmarks_path = path.expanduser(file_path)
+
 
         if not path.isfile(bookmarks_path):
             print("No bookmarks file found!")

--- a/rofi_browser_bookmarks/__init__.py
+++ b/rofi_browser_bookmarks/__init__.py
@@ -15,6 +15,10 @@ def main():
     if len(argv) > 2:
         folder = argv[2]
 
+    file_path = None
+    if len(argv) > 3:
+        file_path = argv[3]
+
     factory = BookmarksParserFactory()
     try:
         parser = factory.make(browser)
@@ -22,7 +26,7 @@ def main():
         print("Available browsers are: google-chrome")
         return
 
-    options = FormatColumns().format(parser.parse(folder=folder))
+    options = FormatColumns().format(parser.parse(folder=folder, file_path=file_path))
 
     try:
         selection = check_output(['rofi', '-i', '-dmenu'], input=options.encode()).decode().strip()


### PR DESCRIPTION
Add new optional file_path argument  to specify where the Bookmarks file is. This is currently hardcoded to `Default` which doesn't work when google-chrome decides to name your profile other things.

Example usage would be:

`rofi-browser-bookmarks google-chrome my_folder ~/.config/google-chrome/my_profile/Bookmarks`
